### PR TITLE
fix: ui to display subfolders in dashboard and update count

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1006,3 +1006,112 @@
   font-size: 11px;
   color: #999;
 }
+
+.folder-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.folder-row:hover {
+  border-color: #ccc;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.folder-row-icon {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f6f6f6;
+  border-radius: 4px;
+  color: #666;
+}
+
+.folder-row-icon svg {
+  width: 22px;
+  height: 16px;
+}
+
+.folder-row-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.folder-row-name {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folder-row-meta {
+  font-size: 12px;
+  color: #999;
+}
+
+.folder-tile {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+}
+
+.folder-tile:hover {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.10);
+  border-color: #bbb;
+}
+
+.folder-tile-preview {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.folder-tile-icon {
+  width: 54px;
+  height: 36px;
+  color: #666;
+}
+
+.folder-tile-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px;
+}
+
+.folder-tile-name {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folder-tile-meta {
+  font-size: 11px;
+  color: #999;
+}

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,16 +1,50 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useFileIndex } from "../hooks/useFileContext";
 import { FileCard } from "./FileCard";
 import { UploadZone } from "./UploadZone";
 
+function getFolderName(path: string): string {
+  if (path === "/") return "My Drive";
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] || path;
+}
+
+function isDirectChildFolder(parentFolder: string, candidateFolder: string): boolean {
+  if (candidateFolder === "/" || candidateFolder === parentFolder) return false;
+
+  if (parentFolder === "/") {
+    return candidateFolder.split("/").filter(Boolean).length === 1;
+  }
+
+  if (!candidateFolder.startsWith(`${parentFolder}/`)) return false;
+  const relative = candidateFolder.slice(parentFolder.length + 1);
+  return relative.length > 0 && !relative.includes("/");
+}
+
 export function FileList() {
-  const { files, currentFolder, loading } = useFileIndex();
+  const { files, folders, currentFolder, setCurrentFolder, loading } = useFileIndex();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isGridView = viewMode === "grid";
 
-  const currentFiles = files
-    .filter((f) => f.folder === currentFolder)
-    .filter((f) => f.name.toLowerCase().includes(searchQuery.toLowerCase()));
+  const currentFolders = useMemo(
+    () =>
+      folders
+        .filter((folder) => isDirectChildFolder(currentFolder, folder))
+        .filter((folder) => getFolderName(folder).toLowerCase().includes(normalizedQuery)),
+    [folders, currentFolder, normalizedQuery]
+  );
+
+  const currentFiles = useMemo(
+    () =>
+      files
+        .filter((f) => f.folder === currentFolder)
+        .filter((f) => f.name.toLowerCase().includes(normalizedQuery)),
+    [files, currentFolder, normalizedQuery]
+  );
+
+  const hasItems = currentFolders.length > 0 || currentFiles.length > 0;
 
   if (loading) {
     return (
@@ -67,15 +101,65 @@ export function FileList() {
         </div>
       </div>
 
-      {currentFiles.length === 0 ? (
+      {!hasItems ? (
         <div className="empty-state">
-          <p>{searchQuery ? "No files match your search" : "No files in this folder"}</p>
-          <p className="empty-hint">{!searchQuery && "Drop files above to upload"}</p>
+          <p>{normalizedQuery ? "No files or folders match your search" : "No files or folders in this folder"}</p>
+          <p className="empty-hint">{!normalizedQuery && "Drop files above to upload"}</p>
         </div>
       ) : (
-        <div className={viewMode === "grid" ? "file-grid" : "file-list-view"}>
+        <div className={isGridView ? "file-grid" : "file-list-view"}>
+          {currentFolders.map((folderPath) =>
+            isGridView ? (
+              <button
+                key={folderPath}
+                type="button"
+                className="folder-tile"
+                onClick={() => setCurrentFolder(folderPath)}
+                title={`Open ${getFolderName(folderPath)}`}
+              >
+                <div className="folder-tile-preview">
+                  <svg className="folder-tile-icon" viewBox="0 0 24 16" fill="none" aria-hidden="true">
+                    <path
+                      d="M2 2.5C2 1.67 2.67 1 3.5 1H8.7C9.14 1 9.56 1.2 9.84 1.54L11.18 3.2C11.47 3.56 11.9 3.76 12.36 3.76H20.5C21.33 3.76 22 4.43 22 5.26V13.5C22 14.33 21.33 15 20.5 15H3.5C2.67 15 2 14.33 2 13.5V2.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+                <div className="folder-tile-footer">
+                  <span className="folder-tile-name" title={getFolderName(folderPath)}>
+                    {getFolderName(folderPath)}
+                  </span>
+                  <span className="folder-tile-meta">Folder</span>
+                </div>
+              </button>
+            ) : (
+              <button
+                key={folderPath}
+                type="button"
+                className="folder-row"
+                onClick={() => setCurrentFolder(folderPath)}
+                title={`Open ${getFolderName(folderPath)}`}
+              >
+                <div className="folder-row-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 16" fill="none">
+                    <path
+                      d="M2 2.5C2 1.67 2.67 1 3.5 1H8.7C9.14 1 9.56 1.2 9.84 1.54L11.18 3.2C11.47 3.56 11.9 3.76 12.36 3.76H20.5C21.33 3.76 22 4.43 22 5.26V13.5C22 14.33 21.33 15 20.5 15H3.5C2.67 15 2 14.33 2 13.5V2.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+                <div className="folder-row-info">
+                  <span className="folder-row-name" title={getFolderName(folderPath)}>
+                    {getFolderName(folderPath)}
+                  </span>
+                  <span className="folder-row-meta">Folder</span>
+                </div>
+              </button>
+            )
+          )}
+
           {currentFiles.map((file) => (
-            <FileCard key={file.hash} file={file} viewMode={viewMode}/>
+            <FileCard key={file.hash} file={file} viewMode={viewMode} />
           ))}
         </div>
       )}

--- a/src/components/FolderSidebar.tsx
+++ b/src/components/FolderSidebar.tsx
@@ -41,8 +41,24 @@ export function FolderSidebar({ isOpen, onClose }: FolderSidebarProps) {
     onClose();
   };
 
-  const getFileCount = (folder: string) => {
-    return files.filter((f) => f.folder === folder).length;
+  const isDirectChildFolder = (parentFolder: string, candidateFolder: string) => {
+    if (candidateFolder === "/" || candidateFolder === parentFolder) return false;
+
+    if (parentFolder === "/") {
+      return candidateFolder.split("/").filter(Boolean).length === 1;
+    }
+
+    if (!candidateFolder.startsWith(`${parentFolder}/`)) return false;
+    const relative = candidateFolder.slice(parentFolder.length + 1);
+    return relative.length > 0 && !relative.includes("/");
+  };
+
+  const getItemCount = (folder: string) => {
+    const directFileCount = files.filter((f) => f.folder === folder).length;
+    const directFolderCount = folders.filter((candidate) =>
+      isDirectChildFolder(folder, candidate)
+    ).length;
+    return directFileCount + directFolderCount;
   };
 
   const getFolderName = (path: string) => {
@@ -127,7 +143,7 @@ export function FolderSidebar({ isOpen, onClose }: FolderSidebarProps) {
                 {folder === "/" ? "◊" : "▸"}
               </span>
               <span className="folder-name">{getFolderName(folder)}</span>
-              <span className="folder-count">{getFileCount(folder)}</span>
+              <span className="folder-count">{getItemCount(folder)}</span>
             </button>
           ))}
         </nav>


### PR DESCRIPTION
## Summary
@abh3po do let me know if these changes are desired 
This PR fixes folder navigation visibility in the drive UI.

- Shows direct child folders in the main dashboard (grid + list views).
- Makes folder items in the dashboard clickable to enter that folder.
- Updates sidebar counts to include direct files + direct child folders.
- Adjusts empty/search states to account for both files and folders.

preview images:
Before:

<img width="1897" height="853" alt="Screenshot 2026-04-07 001901" src="https://github.com/user-attachments/assets/167f1835-e782-40db-a431-8e7dcf3d91fa" />


After:

<img width="1899" height="858" alt="Screenshot 2026-04-07 004129" src="https://github.com/user-attachments/assets/62ad5d6c-320c-4662-a402-90e225797ceb" />


