### PR TITLE
refactor: file menu position

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1633,7 +1633,7 @@
 .tile-menu {
   top: calc(100% + 8px);
   bottom: auto;
-  right: -14px;
+  right: -18px;
   margin: 0;
   z-index: 60;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1549,6 +1549,10 @@
   border-radius: 8px 8px 0 0;
 }
 
+.file-tile-preview.menu-open {
+  overflow: visible;
+}
+
 .file-tile-img {
   width: 100%;
   height: 100%;
@@ -1627,11 +1631,11 @@
 }
 
 .tile-menu {
-  bottom: 100%;
-  top: auto;
-  right: 0;
-  margin-bottom: 4px;
-  z-index: 50;
+  top: calc(100% + 8px);
+  bottom: auto;
+  right: -14px;
+  margin: 0;
+  z-index: 60;
 }
 
 /* Footer */

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -264,7 +264,7 @@ export function FileCard({
         )}
         <div className={`file-tile ${showMenu ? "menu-open" : ""} ${selected ? "selected" : ""}`}>
           {/* Preview area */}
-          <div className="file-tile-preview">
+          <div className={`file-tile-preview ${showMenu ? "menu-open" : ""}`}>
             {selectionControl}
             {hasPreview ? (
               <img src={preview} alt={file.name} className="file-tile-img" />
@@ -299,6 +299,7 @@ export function FileCard({
               >
                 ⋮
               </button>
+
               {showMenu && (
                 <div className="file-menu tile-menu" onClick={(e) => e.stopPropagation()}>
                   <button onClick={handleMoveClick} className="move-btn">Move to Folder</button>


### PR DESCRIPTION
@abh3po This PR makes the action menu open reliably on click, closes on backdrop click, currently the screen just flickers when menu is opnend, and m menu is positioned to the right/below the trigger instead of appearing clipped or flickering. 
Before:
<img width="1902" height="738" alt="Screenshot 2026-04-15 110829" src="https://github.com/user-attachments/assets/8e566fd3-7d86-41fc-b6a1-dc64240ac244" />

After:
<img width="604" height="412" alt="Screenshot 2026-04-15 111308" src="https://github.com/user-attachments/assets/98a0a30b-5cf2-484f-b96e-483e6b5e4ff0" />

