### PR TITLE
feat/decentralized share links

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -894,6 +894,10 @@
   border-radius: 8px 8px 0 0;
 }
 
+.file-tile-preview.menu-open {
+  overflow: visible;
+}
+
 .file-tile-img {
   width: 100%;
   height: 100%;
@@ -977,11 +981,11 @@
 }
 
 .tile-menu {
-  bottom: 100%;
-  top: auto;
-  right: 0;
-  margin-bottom: 4px;
-  z-index: 50;
+  top: calc(100% + 8px);
+  bottom: auto;
+  right: -14px;
+  margin: 0;
+  z-index: 60;
 }
 
 /* Footer */

--- a/src/App.css
+++ b/src/App.css
@@ -537,6 +537,10 @@
   color: #0066cc;
 }
 
+.file-menu button.share-btn {
+  color: #0b7a57;
+}
+
 .file-error {
   position: absolute;
   bottom: -24px;
@@ -605,6 +609,261 @@
 .move-dialog-body {
   padding: 16px 24px 24px;
   overflow-y: auto;
+}
+
+.share-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.share-dialog {
+  background: #fff;
+  border-radius: 10px;
+  width: min(94vw, 700px);
+  max-height: 84vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.share-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 18px 20px;
+}
+
+.share-dialog-header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.share-dialog-header button {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 24px;
+  color: #666;
+}
+
+.share-dialog-header button:hover {
+  background: #f2f2f2;
+}
+
+.share-dialog-body {
+  overflow-y: auto;
+  padding: 16px 20px 20px;
+}
+
+.share-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.share-form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #555;
+}
+
+.share-form-grid input,
+.share-form-grid select {
+  width: 100%;
+  height: 36px;
+  border: 1px solid #d5d5d5;
+  border-radius: 6px;
+  padding: 0 10px;
+  font-size: 14px;
+}
+
+.share-form-grid .share-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding-top: 22px;
+}
+
+.share-form-grid .share-checkbox input {
+  width: auto;
+  height: auto;
+}
+
+.share-actions-row {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.share-actions-row button {
+  height: 36px;
+  border: none;
+  border-radius: 6px;
+  padding: 0 12px;
+  background: #111;
+  color: #fff;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.share-actions-row button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.share-actions-row input {
+  height: 36px;
+  border: 1px solid #d5d5d5;
+  border-radius: 6px;
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+.share-error {
+  margin-top: 10px;
+  color: #c00;
+  font-size: 13px;
+}
+
+.share-empty {
+  color: #777;
+  font-size: 13px;
+}
+
+.share-link-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.share-link-item {
+  border: 1px solid #e4e4e4;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.share-link-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  font-size: 12px;
+  color: #666;
+}
+
+.share-link-main strong {
+  color: #111;
+}
+
+.share-revoke-btn {
+  border: 1px solid #e0b9b9;
+  background: #fff5f5;
+  color: #b10000;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 6px 10px;
+}
+
+.share-revoke-btn:hover {
+  background: #ffecec;
+}
+
+.share-page {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: radial-gradient(circle at 20% 10%, #f4f8ff 0%, #fff 42%, #f8faf8 100%);
+}
+
+.share-card {
+  width: min(92vw, 560px);
+  border: 1px solid #e4e9e4;
+  border-radius: 14px;
+  background: #fff;
+  padding: 24px;
+  box-shadow: 0 16px 34px rgba(22, 39, 27, 0.08);
+}
+
+.share-card h1 {
+  margin: 0 0 14px;
+  font-size: 24px;
+}
+
+.share-file-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid #e4e4e4;
+  background: #fcfffc;
+  margin-bottom: 14px;
+}
+
+.share-file-meta strong {
+  font-size: 15px;
+  color: #172117;
+}
+
+.share-file-meta span {
+  font-size: 13px;
+  color: #5f6d5f;
+}
+
+.share-password-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.share-password-row input {
+  height: 38px;
+  border: 1px solid #d5dbd5;
+  border-radius: 8px;
+  padding: 0 12px;
+  font-size: 14px;
+}
+
+.share-password-row button,
+.share-download-btn {
+  height: 38px;
+  border: none;
+  border-radius: 8px;
+  padding: 0 14px;
+  background: #123d2e;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.share-password-row button:hover,
+.share-download-btn:hover {
+  background: #0f3125;
+}
+
+.share-download-btn:disabled {
+  opacity: 0.65;
+  cursor: default;
 }
 
 .folder-list-move {
@@ -750,6 +1009,14 @@
     inset: 0;
     background: rgba(0, 0, 0, 0.4);
     z-index: 199;
+  }
+
+  .share-actions-row {
+    grid-template-columns: 1fr;
+  }
+
+  .share-password-row {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Header } from "./components/Header";
 import { FolderSidebar } from "./components/FolderSidebar";
 import { FileList } from "./components/FileList";
 import { SignIn } from "./components/SignIn/SignIn";
+import { ShareAccessPage } from "./components/ShareAccessPage";
 import "./App.css";
 
 function DriveLayout() {
@@ -34,6 +35,13 @@ function DriveLayout() {
 }
 
 function App() {
+  const path = window.location.pathname;
+  const shareMatch = path.match(/^\/share\/([^/]+)$/);
+
+  if (shareMatch) {
+    return <ShareAccessPage shareId={decodeURIComponent(shareMatch[1])} />;
+  }
+
   return (
     <ProfileProvider>
       <BlossomServerProvider>

--- a/src/Provider/FileIndexProvider.tsx
+++ b/src/Provider/FileIndexProvider.tsx
@@ -5,18 +5,24 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
-import type { FileMetadata } from "../types/metadata";
+import type { FileMetadata, ShareLink, ShareRole } from "../types/metadata";
 import {
   fetchFileIndex,
   saveFileMetadata,
   deleteFileMetadata,
   extractFolders,
+  publishPublicShareEvent,
 } from "../services/fileIndex";
 import { encryptFileWithKey , encryptFile } from "../crypto";
 import { createAuthEvent } from "../auth";
 import { BlossomClient } from "../blossom";
 import { useProfileContext } from "../hooks/useProfileContext";
 import { previewFile } from "../services/Preview/previewManager";
+import {
+  buildShareLink,
+  createPasswordVerifier,
+  createShareToken,
+} from "../utils/shareTokens";
 
 const CUSTOM_FOLDERS_KEY = "formstr-drive-custom-folders";
 
@@ -33,6 +39,14 @@ export interface FileIndexContextType {
   deleteFile: (hash: string) => Promise<void>;
   moveFile: (hash: string, newFolder: string) => Promise<void>;
   renameFile: (hash: string, newName: string) => Promise<void>;
+  createShareLink: (input: {
+    hash: string;
+    role: ShareRole;
+    canReshare: boolean;
+    expiresAt?: number;
+    password?: string;
+  }) => Promise<{ link: string; share: ShareLink }>;
+  revokeShareLink: (hash: string, shareId: string) => Promise<void>;
   refresh: () => Promise<void>;
 }
 
@@ -163,6 +177,128 @@ export function FileIndexProvider({ children }: { children: ReactNode }) {
     [files]
   );
 
+  const createShareLink = useCallback(
+    async (input: {
+      hash: string;
+      role: ShareRole;
+      canReshare: boolean;
+      expiresAt?: number;
+      password?: string;
+    }) => {
+      const file = files.find((f) => f.hash === input.hash);
+      if (!file) {
+        throw new Error("File not found");
+      }
+
+      const token = createShareToken();
+      const now = Date.now();
+
+      const passwordConfig = input.password
+        ? await createPasswordVerifier(input.password)
+        : undefined;
+
+      const share: ShareLink = {
+        id: token.shareId,
+        createdAt: now,
+        capabilitySecret: token.secret,
+        policy: {
+          role: input.role,
+          canReshare: input.canReshare,
+          requiresPassword: !!input.password,
+          ...(input.expiresAt ? { expiresAt: input.expiresAt } : {}),
+          ...(passwordConfig
+            ? {
+                passwordSalt: passwordConfig.salt,
+                passwordVerifier: passwordConfig.verifier,
+              }
+            : {}),
+        },
+      };
+
+      const updated: FileMetadata = {
+        ...file,
+        shareLinks: [share, ...(file.shareLinks ?? [])],
+      };
+
+      await Promise.all([
+        saveFileMetadata(updated),
+        publishPublicShareEvent(
+          {
+            shareId: token.shareId,
+            fileHash: file.hash,
+            fileName: file.name,
+            fileType: file.type,
+            fileSize: file.size,
+            server: file.server,
+            encryptionKey: file.encryptionKey,
+            createdAt: now,
+            policy: share.policy,
+          },
+          token.secret
+        ),
+      ]);
+      setFiles((prev) => prev.map((f) => (f.hash === input.hash ? updated : f)));
+
+      return {
+        link: buildShareLink(window.location.origin, {
+          shareId: token.shareId,
+          secret: token.secret,
+        }),
+        share,
+      };
+    },
+    [files]
+  );
+
+  const revokeShareLink = useCallback(
+    async (hash: string, shareId: string) => {
+      const file = files.find((f) => f.hash === hash);
+      if (!file) {
+        throw new Error("File not found");
+      }
+
+      const shareLinks = file.shareLinks ?? [];
+      const existingShare = shareLinks.find((share) => share.id === shareId);
+      if (!existingShare) {
+        throw new Error("Share not found");
+      }
+
+      if (!existingShare.capabilitySecret) {
+        throw new Error("Cannot revoke legacy share without stored capability key");
+      }
+
+      const revokedAt = Date.now();
+
+      const updated: FileMetadata = {
+        ...file,
+        shareLinks: shareLinks.map((share) =>
+          share.id === shareId ? { ...share, revokedAt } : share
+        ),
+      };
+
+      await Promise.all([
+        saveFileMetadata(updated),
+        publishPublicShareEvent(
+          {
+            shareId: existingShare.id,
+            fileHash: file.hash,
+            fileName: file.name,
+            fileType: file.type,
+            fileSize: file.size,
+            server: file.server,
+            encryptionKey: file.encryptionKey,
+            createdAt: existingShare.createdAt,
+            revokedAt,
+            policy: existingShare.policy,
+          },
+          existingShare.capabilitySecret
+        ),
+      ]);
+      setFiles((prev) => prev.map((f) => (f.hash === hash ? updated : f)));
+    },
+    [files]
+  );
+
   return (
     <FileIndexContext.Provider
       value={{
@@ -178,6 +314,8 @@ export function FileIndexProvider({ children }: { children: ReactNode }) {
         deleteFile,
         moveFile,
         renameFile,
+        createShareLink,
+        revokeShareLink,
         refresh,
       }}
     >

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -162,7 +162,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
   if (viewMode === "grid") {
     return (
       <>
-        {(showMenu || showGridActions) && (
+        {showMenu && (
           <div
             className="file-menu-backdrop"
             onClick={() => {
@@ -180,7 +180,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
           onClick={() => setShowGridActions(true)}
         >
           {/* Preview area */}
-          <div className="file-tile-preview">
+          <div className={`file-tile-preview ${showMenu ? "menu-open" : ""}`}>
             {hasPreview ? (
               <img src={preview} alt={file.name} className="file-tile-img" />
             ) : null}
@@ -208,13 +208,14 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
                 className="tile-action-btn"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setShowMenu(!showMenu);
+                  setShowMenu((prev) => !prev);
                   setShowGridActions(true);
                 }}
                 title="More"
               >
                 ⋮
               </button>
+
               {showMenu && (
                 <div className="file-menu tile-menu" onClick={(e) => e.stopPropagation()}>
                   <button onClick={handleMoveClick} className="move-btn">Move to Folder</button>

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -4,6 +4,7 @@ import { useFileIndex } from "../hooks/useFileContext";
 import { decryptFile, decryptFileWithKey } from "../crypto";
 import { createAuthEvent } from "../auth";
 import { BlossomClient } from "../blossom";
+import { ShareDialog } from "./ShareDialog";
 
 interface FileCardProps {
   file: FileMetadata;
@@ -48,6 +49,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showGridActions, setShowGridActions] = useState(false);
   const [showMoveDialog, setShowMoveDialog] = useState(false);
+  const [showShareDialog, setShowShareDialog] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [previewloaded, setPreviewloaded] = useState(false);
   const [preview, setPreview] = useState<string | null>(null);
@@ -119,6 +121,11 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
     setShowMoveDialog(true);
   };
 
+  const handleShareClick = () => {
+    setShowMenu(false);
+    setShowShareDialog(true);
+  };
+
   const handleMove = async (newFolder: string) => {
     try {
       await moveFile(file.hash, newFolder);
@@ -130,6 +137,9 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
 
   const icon = getFileIcon(file.type);
   const hasPreview = previewloaded && !!preview;
+  const shareDialog = showShareDialog && (
+    <ShareDialog file={file} onClose={() => setShowShareDialog(false)} />
+  );
 
   const moveDialog = showMoveDialog && (
     <div className="move-dialog-overlay" onClick={() => setShowMoveDialog(false)}>
@@ -219,12 +229,12 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
               {showMenu && (
                 <div className="file-menu tile-menu" onClick={(e) => e.stopPropagation()}>
                   <button onClick={handleMoveClick} className="move-btn">Move to Folder</button>
+                  <button onClick={handleShareClick} className="share-btn">Share</button>
                   <button onClick={handleDelete} className="delete-btn">Delete</button>
                 </div>
               )}
             </div>
           </div>
-
           {/* Footer */}
           <div className="file-tile-footer">
             <span className="file-tile-name" title={file.name}>{file.name}</span>
@@ -234,6 +244,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
           {error && <div className="file-error">{error}</div>}
         </div>
         {moveDialog}
+        {shareDialog}
       </>
     );
   }
@@ -266,6 +277,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
           {showMenu && (
             <div className="file-menu" onClick={(e) => e.stopPropagation()}>
               <button onClick={handleMoveClick} className="move-btn">Move to Folder</button>
+              <button onClick={handleShareClick} className="share-btn">Share</button>
               <button onClick={handleDelete} className="delete-btn">Delete</button>
             </div>
           )}
@@ -273,6 +285,7 @@ export function FileCard({ file, viewMode = "list" }: FileCardProps) {
         {error && <div className="file-error">{error}</div>}
       </div>
       {moveDialog}
+      {shareDialog}
     </>
   );
 }

--- a/src/components/ShareAccessPage.tsx
+++ b/src/components/ShareAccessPage.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from "react";
+import { BlossomClient } from "../blossom";
+import { decryptFileWithKey } from "../crypto";
+import { resolvePublicShareEvent } from "../services/fileIndex";
+import { verifyPassword } from "../utils/shareTokens";
+import type { PublicSharePayload } from "../types/metadata";
+
+interface ShareAccessPageProps {
+  shareId: string;
+}
+
+function readSecretFromHash(): string | null {
+  const hash = window.location.hash.startsWith("#")
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const params = new URLSearchParams(hash);
+  return params.get("k");
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export function ShareAccessPage({ shareId }: ShareAccessPageProps) {
+  const [payload, setPayload] = useState<PublicSharePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [passwordUnlocked, setPasswordUnlocked] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  const secret = useMemo(() => readSecretFromHash(), []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const load = async () => {
+      if (!secret) {
+        setError("Missing share key in URL fragment");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const resolved = await resolvePublicShareEvent(shareId, secret);
+        if (!mounted) return;
+
+        if (!resolved) {
+          setError("Share not found or invalid key");
+          return;
+        }
+
+        if (resolved.revokedAt) {
+          setError("This share link has been revoked");
+          return;
+        }
+
+        if (resolved.policy.expiresAt && resolved.policy.expiresAt < Date.now()) {
+          setError("This share link has expired");
+          return;
+        }
+
+        setPayload(resolved);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to resolve share link");
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      mounted = false;
+    };
+  }, [secret, shareId]);
+
+  const handleUnlock = async () => {
+    if (!payload || !payload.policy.requiresPassword) {
+      setPasswordUnlocked(true);
+      return;
+    }
+
+    if (!payload.policy.passwordSalt || !payload.policy.passwordVerifier) {
+      setError("Share password settings are incomplete");
+      return;
+    }
+
+    const isValid = await verifyPassword(
+      password,
+      payload.policy.passwordSalt,
+      payload.policy.passwordVerifier
+    );
+
+    if (!isValid) {
+      setError("Incorrect password");
+      return;
+    }
+
+    setError(null);
+    setPasswordUnlocked(true);
+  };
+
+  const handleDownload = async () => {
+    if (!payload) return;
+    setDownloading(true);
+    setError(null);
+
+    try {
+      const client = new BlossomClient(payload.server);
+      const blob = await client.download(payload.fileHash);
+      const ciphertext = new TextDecoder().decode(blob);
+      const decrypted = await decryptFileWithKey(ciphertext, payload.encryptionKey);
+
+      const url = URL.createObjectURL(
+        new Blob([decrypted as BlobPart], { type: payload.fileType || "application/octet-stream" })
+      );
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = payload.fileName;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Download failed");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <main className="share-page">
+      <section className="share-card">
+        <h1>Shared file</h1>
+
+        {loading && <p>Resolving secure link...</p>}
+
+        {!loading && payload && (
+          <>
+            <div className="share-file-meta">
+              <strong>{payload.fileName}</strong>
+              <span>{formatSize(payload.fileSize)}</span>
+              <span>Permission: {payload.policy.role}</span>
+              {payload.policy.expiresAt && (
+                <span>Expires: {new Date(payload.policy.expiresAt).toLocaleString()}</span>
+              )}
+            </div>
+
+            {payload.policy.requiresPassword && !passwordUnlocked && (
+              <div className="share-password-row">
+                <input
+                  type="password"
+                  placeholder="Enter share password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                />
+                <button onClick={handleUnlock}>Unlock</button>
+              </div>
+            )}
+
+            {(!payload.policy.requiresPassword || passwordUnlocked) && (
+              <button className="share-download-btn" onClick={handleDownload} disabled={downloading}>
+                {downloading ? "Downloading..." : "Download file"}
+              </button>
+            )}
+          </>
+        )}
+
+        {error && <p className="share-error">{error}</p>}
+      </section>
+    </main>
+  );
+}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from "react";
+import type { FileMetadata, ShareRole } from "../types/metadata";
+import { useFileIndex } from "../hooks/useFileContext";
+
+interface ShareDialogProps {
+  file: FileMetadata;
+  onClose: () => void;
+}
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export function ShareDialog({ file, onClose }: ShareDialogProps) {
+  const { createShareLink, revokeShareLink } = useFileIndex();
+  const [role, setRole] = useState<ShareRole>("viewer");
+  const [canReshare, setCanReshare] = useState(false);
+  const [expiresAtLocal, setExpiresAtLocal] = useState("");
+  const [password, setPassword] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [generatedLink, setGeneratedLink] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const shareLinks = useMemo(() => file.shareLinks ?? [], [file.shareLinks]);
+
+  const handleCreate = async () => {
+    setActionError(null);
+    setCopied(false);
+    setCreating(true);
+    try {
+      const expiresAt = expiresAtLocal ? new Date(expiresAtLocal).getTime() : undefined;
+      if (expiresAt && Number.isNaN(expiresAt)) {
+        throw new Error("Invalid expiration date");
+      }
+
+      const result = await createShareLink({
+        hash: file.hash,
+        role,
+        canReshare,
+        expiresAt,
+        password: password.trim() || undefined,
+      });
+
+      setGeneratedLink(result.link);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to create link");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!generatedLink) return;
+    await navigator.clipboard.writeText(generatedLink);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  const handleRevoke = async (shareId: string) => {
+    setActionError(null);
+    try {
+      await revokeShareLink(file.hash, shareId);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to revoke link");
+    }
+  };
+
+  return (
+    <div className="share-dialog-overlay" onClick={onClose}>
+      <div className="share-dialog" onClick={(event) => event.stopPropagation()}>
+        <div className="share-dialog-header">
+          <h3>Share {file.name}</h3>
+          <button onClick={onClose} aria-label="Close share dialog">
+            ×
+          </button>
+        </div>
+
+        <div className="share-dialog-body">
+          <div className="share-form-grid">
+            <label>
+              Role
+              <select value={role} onChange={(event) => setRole(event.target.value as ShareRole)}>
+                <option value="viewer">Viewer</option>
+                <option value="commenter">Commenter</option>
+                <option value="editor">Editor</option>
+              </select>
+            </label>
+
+            <label>
+              Expires at (optional)
+              <input
+                type="datetime-local"
+                value={expiresAtLocal}
+                onChange={(event) => setExpiresAtLocal(event.target.value)}
+              />
+            </label>
+
+            <label>
+              Password (optional)
+              <input
+                type="password"
+                value={password}
+                placeholder="Require password to open"
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </label>
+
+            <label className="share-checkbox">
+              <input
+                type="checkbox"
+                checked={canReshare}
+                onChange={(event) => setCanReshare(event.target.checked)}
+              />
+              Allow re-share
+            </label>
+          </div>
+
+          <div className="share-actions-row">
+            <button onClick={handleCreate} disabled={creating}>
+              {creating ? "Creating..." : "Create share link"}
+            </button>
+            {generatedLink && (
+              <>
+                <input readOnly value={generatedLink} aria-label="Generated share link" />
+                <button onClick={handleCopy}>{copied ? "Copied" : "Copy"}</button>
+              </>
+            )}
+          </div>
+
+          {actionError && <div className="share-error">{actionError}</div>}
+
+          <h4>Existing links</h4>
+          {shareLinks.length === 0 ? (
+            <p className="share-empty">No share links yet.</p>
+          ) : (
+            <div className="share-link-list">
+              {shareLinks.map((share) => {
+                const status = share.revokedAt
+                  ? "Revoked"
+                  : share.policy.expiresAt && share.policy.expiresAt < Date.now()
+                    ? "Expired"
+                    : "Active";
+
+                return (
+                  <div key={share.id} className="share-link-item">
+                    <div className="share-link-main">
+                      <strong>{status}</strong>
+                      <span>Role: {share.policy.role}</span>
+                      <span>Re-share: {share.policy.canReshare ? "Yes" : "No"}</span>
+                      <span>Created: {formatTimestamp(share.createdAt)}</span>
+                      {share.policy.expiresAt && <span>Expires: {formatTimestamp(share.policy.expiresAt)}</span>}
+                    </div>
+                    {!share.revokedAt && (
+                      <button className="share-revoke-btn" onClick={() => handleRevoke(share.id)}>
+                        Revoke
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/fileIndex.ts
+++ b/src/services/fileIndex.ts
@@ -1,8 +1,11 @@
 import { SimplePool, type Filter } from "nostr-tools";
-import type { FileMetadata, NostrEvent } from "../types/metadata";
+import type { FileMetadata, NostrEvent, PublicSharePayload } from "../types/metadata";
+import { decryptSharePayload, encryptSharePayload } from "../utils/shareTokens";
 
 const METADATA_KIND = 34578;
+const PUBLIC_SHARE_KIND = 34579;
 const CLIENT_TAG = "formstr-drive";
+const FETCH_TIMEOUT_MS = 10000;
 
 const RELAYS = [
   "wss://relay.damus.io",
@@ -13,6 +16,31 @@ const RELAYS = [
 async function getNostr() {
   if (!window.nostr) throw new Error("Nostr signer not found");
   return window.nostr;
+}
+
+function collectEvents(filter: Filter): Promise<any[]> {
+  const pool = new SimplePool();
+
+  return new Promise((resolve) => {
+    const events: any[] = [];
+    const seenIds = new Set<string>();
+
+    // @ts-ignore subscribeMany accepts a single filter at runtime in this codebase
+    const sub = pool.subscribeMany(RELAYS, filter, {
+      onevent(event) {
+        if (!seenIds.has(event.id)) {
+          seenIds.add(event.id);
+          events.push(event);
+        }
+      },
+    });
+
+    setTimeout(() => {
+      sub.close();
+      pool.close(RELAYS);
+      resolve(events);
+    }, FETCH_TIMEOUT_MS);
+  });
 }
 
 async function encryptMetadata(metadata: FileMetadata): Promise<string> {
@@ -33,43 +61,16 @@ export async function fetchFileIndex(pubkey: string): Promise<FileMetadata[]> {
   console.log("[FileIndex] Starting fetch from relays:", RELAYS);
   console.log("[FileIndex] User pubkey:", pubkey);
 
-  const pool = new SimplePool();
-
-  return new Promise((resolve) => {
-    const filter: Filter = {
-      kinds: [METADATA_KIND],
-      authors: [pubkey],
-    };
+  const filter: Filter = {
+    kinds: [METADATA_KIND],
+    authors: [pubkey],
+  };
     console.log("[FileIndex] Query filter:", JSON.stringify(filter));
     console.log("[FileIndex] Filter as array:", JSON.stringify([filter]));
 
-    const events: any[] = [];
-    const seenIds = new Set<string>();
-
-    // Subscribe to relays
-    // @ts-ignore - try passing filter directly, not as array
-    const sub = pool.subscribeMany(RELAYS, filter, {
-        onevent(event) {
-          if (!seenIds.has(event.id)) {
-            console.log("[FileIndex] Received event:", event.id);
-            seenIds.add(event.id);
-            events.push(event);
-          }
-        },
-        oneose() {
-          console.log("[FileIndex] EOSE received from relay");
-        },
-        onclose(reasons) {
-          console.log("[FileIndex] Subscription closed:", reasons);
-        },
-      }
-    );
-
-    // Wait 10 seconds for events to come in, then process
-    setTimeout(async () => {
+  return new Promise((resolve) => {
+    collectEvents(filter).then(async (events) => {
       console.log(`[FileIndex] Timeout reached, processing ${events.length} events`);
-      sub.close();
-      pool.close(RELAYS);
 
       const files: FileMetadata[] = [];
       const seenHashes = new Set<string>();
@@ -109,8 +110,66 @@ export async function fetchFileIndex(pubkey: string): Promise<FileMetadata[]> {
 
       console.log(`[FileIndex] Successfully loaded ${files.length} files`);
       resolve(files);
-    }, 10000); // 10 second timeout
+    });
   });
+}
+
+export async function publishPublicShareEvent(payload: PublicSharePayload, secret: string): Promise<void> {
+  const nostr = await getNostr();
+  const pubkey = await nostr.getPublicKey();
+  const pool = new SimplePool();
+
+  try {
+    const encrypted = await encryptSharePayload(payload, secret);
+    const event: NostrEvent = {
+      kind: PUBLIC_SHARE_KIND,
+      pubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ["d", payload.shareId],
+        ["client", CLIENT_TAG],
+        ["share", "public"],
+      ],
+      content: JSON.stringify(encrypted),
+    };
+
+    const signedEvent = await nostr.signEvent(event as object);
+    const publishPromises = pool.publish(RELAYS, signedEvent as any);
+    await Promise.any(publishPromises);
+  } finally {
+    pool.close(RELAYS);
+  }
+}
+
+export async function resolvePublicShareEvent(
+  shareId: string,
+  secret: string
+): Promise<PublicSharePayload | null> {
+  const filter: Filter = {
+    kinds: [PUBLIC_SHARE_KIND],
+    "#d": [shareId],
+  };
+
+  const events = await collectEvents(filter);
+  if (events.length === 0) {
+    return null;
+  }
+
+  events.sort((a, b) => b.created_at - a.created_at);
+
+  for (const event of events) {
+    try {
+      const parsed = JSON.parse(event.content) as { ciphertext: string; iv: string };
+      const payload = await decryptSharePayload(parsed.ciphertext, parsed.iv, secret);
+      if (payload.shareId === shareId) {
+        return payload;
+      }
+    } catch {
+      // Ignore incompatible events and continue scanning older candidates.
+    }
+  }
+
+  return null;
 }
 
 export async function saveFileMetadata(metadata: FileMetadata): Promise<void> {

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -1,3 +1,35 @@
+export type ShareRole = "viewer" | "commenter" | "editor";
+
+export interface SharePolicy {
+  role: ShareRole;
+  canReshare: boolean;
+  expiresAt?: number;
+  requiresPassword: boolean;
+  passwordSalt?: string;
+  passwordVerifier?: string;
+}
+
+export interface ShareLink {
+  id: string;
+  createdAt: number;
+  revokedAt?: number;
+  capabilitySecret?: string;
+  policy: SharePolicy;
+}
+
+export interface PublicSharePayload {
+  shareId: string;
+  fileHash: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  server: string;
+  encryptionKey: string;
+  createdAt: number;
+  revokedAt?: number;
+  policy: SharePolicy;
+}
+
 export interface FileMetadata {
   name: string;
   hash: string;
@@ -9,6 +41,7 @@ export interface FileMetadata {
   encryptionKey: string; // Hex-encoded private key used to encrypt this file
   deleted?: boolean;
   previewHash?: string;
+  shareLinks?: ShareLink[];
 }
 
 export interface FolderInfo {

--- a/src/utils/shareTokens.ts
+++ b/src/utils/shareTokens.ts
@@ -35,6 +35,12 @@ function base64UrlToBytes(value: string): Uint8Array {
   return bytes;
 }
 
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const out = new Uint8Array(bytes.byteLength);
+  out.set(bytes);
+  return out.buffer;
+}
+
 function randomBase64Url(byteLength: number): string {
   const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
   return bytesToBase64Url(bytes);
@@ -82,7 +88,11 @@ export async function encryptSharePayload(
   const key = await secretToAesKey(secret);
   const ivBytes = crypto.getRandomValues(new Uint8Array(12));
   const plaintext = new TextEncoder().encode(JSON.stringify(payload));
-  const encrypted = await crypto.subtle.encrypt({ name: "AES-GCM", iv: ivBytes }, key, plaintext);
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: toArrayBuffer(ivBytes) },
+    key,
+    toArrayBuffer(plaintext)
+  );
 
   return {
     ciphertext: bytesToBase64Url(new Uint8Array(encrypted)),
@@ -97,9 +107,9 @@ export async function decryptSharePayload(
 ): Promise<PublicSharePayload> {
   const key = await secretToAesKey(secret);
   const decrypted = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: base64UrlToBytes(iv) },
+    { name: "AES-GCM", iv: toArrayBuffer(base64UrlToBytes(iv)) },
     key,
-    base64UrlToBytes(ciphertext)
+    toArrayBuffer(base64UrlToBytes(ciphertext))
   );
 
   const json = new TextDecoder().decode(decrypted);

--- a/src/utils/shareTokens.ts
+++ b/src/utils/shareTokens.ts
@@ -1,0 +1,107 @@
+import type { PublicSharePayload, ShareRole } from "../types/metadata";
+
+export interface ShareTokenPayload {
+  shareId: string;
+  secret: string;
+}
+
+export interface CreateShareOptions {
+  role: ShareRole;
+  canReshare: boolean;
+  expiresAt?: number;
+  password?: string;
+}
+
+export interface CreateShareResult {
+  shareId: string;
+  secret: string;
+  passwordSalt?: string;
+  passwordVerifier?: string;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  const bin = String.fromCharCode(...bytes);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function randomBase64Url(byteLength: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  return bytesToBase64Url(bytes);
+}
+
+export function createShareToken(): ShareTokenPayload {
+  return {
+    shareId: randomBase64Url(16),
+    secret: randomBase64Url(24),
+  };
+}
+
+export function buildShareLink(origin: string, payload: ShareTokenPayload): string {
+  const cleanOrigin = origin.replace(/\/$/, "");
+  return `${cleanOrigin}/share/${payload.shareId}#k=${payload.secret}`;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const arr = Array.from(new Uint8Array(digest));
+  return arr.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function secretToAesKey(secret: string): Promise<CryptoKey> {
+  const hashBytes = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", hashBytes, "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+
+export async function createPasswordVerifier(password: string): Promise<{ salt: string; verifier: string }> {
+  const salt = randomBase64Url(16);
+  const verifier = await sha256Hex(`${salt}:${password}`);
+  return { salt, verifier };
+}
+
+export async function verifyPassword(password: string, salt: string, verifier: string): Promise<boolean> {
+  const candidate = await sha256Hex(`${salt}:${password}`);
+  return candidate === verifier;
+}
+
+export async function encryptSharePayload(
+  payload: PublicSharePayload,
+  secret: string
+): Promise<{ ciphertext: string; iv: string }> {
+  const key = await secretToAesKey(secret);
+  const ivBytes = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+  const encrypted = await crypto.subtle.encrypt({ name: "AES-GCM", iv: ivBytes }, key, plaintext);
+
+  return {
+    ciphertext: bytesToBase64Url(new Uint8Array(encrypted)),
+    iv: bytesToBase64Url(ivBytes),
+  };
+}
+
+export async function decryptSharePayload(
+  ciphertext: string,
+  iv: string,
+  secret: string
+): Promise<PublicSharePayload> {
+  const key = await secretToAesKey(secret);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: base64UrlToBytes(iv) },
+    key,
+    base64UrlToBytes(ciphertext)
+  );
+
+  const json = new TextDecoder().decode(decrypted);
+  return JSON.parse(json) as PublicSharePayload;
+}


### PR DESCRIPTION
### Summary

@abh3po This PR adds decentralized file sharing to the app. Users can create shareable links from file actions, configure permissions, set optional expiration and passwords, and manage active links from the share modal. It also introduces a public share access route so anyone with a valid link can open and download shared files without a backend. I have some more plans to add to this to like add preview when a user opens the link to add preview like gdrive 

### Spec

- Added share metadata types for roles, permissions, revocation, and public share payloads.
- Added share token utilities for generating capability links and encrypting/decrypting public share payloads.
- Extended file index state to create and revoke share links.
- Added a Share action to file menus and a Share dialog for:
  - viewer / commenter / editor roles
  - re-share toggle
  - optional expiration
  - optional password
  - copy link
  - revoke existing links
- Added a public share access page at /share/:id.
- Added decentralized public share event publishing and resolution through Nostr relays.
- Added styling for share dialogs and the public share page.
- Wired the app router to render the public share page when a share URL is opened.

### Working

- Share links are generated from the current site origin, so they will use localhost in dev and the deployed domain in production.
- Public share access works through a URL fragment secret, so the secret is not sent to the server.
- Share links can be revoked by the owner from the share dialog.
how it works in action:

https://github.com/user-attachments/assets/7b8a4a4a-04be-47af-b2c1-279a41dad237


### Notes
- This pr uses code from #11 to show the well positioned menu without flicker.
- This is a decentralized implementation: there is no backend token service.
- Commenter and editor permissions are stored and displayed, but the strongest enforcement path still depends on Nostr identity for future write-action gating.
