### PR TITLE
Fix: Restore file display, hide bulk action bar, and cache previews

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -360,7 +360,6 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding-bottom: 120px;
 }
 
 .bulk-action-bar {
@@ -540,6 +539,19 @@
   justify-content: center;
   flex-shrink: 0;
   cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+/* Show checkbox when parent card/tile is hovered */
+.file-card:hover .file-select,
+.file-tile:hover .file-select {
+  opacity: 1;
+}
+
+/* Always show when checked */
+.file-select:has(input:checked) {
+  opacity: 1;
 }
 
 .file-select input {

--- a/src/App.css
+++ b/src/App.css
@@ -1561,6 +1561,10 @@
   border-radius: 8px 8px 0 0;
 }
 
+.file-tile-preview.menu-open {
+  overflow: visible;
+}
+
 .file-tile-img {
   width: 100%;
   height: 100%;
@@ -1639,11 +1643,11 @@
 }
 
 .tile-menu {
-  bottom: 100%;
-  top: auto;
-  right: 0;
-  margin-bottom: 4px;
-  z-index: 50;
+  top: calc(100% + 8px);
+  bottom: auto;
+  right: -18px;
+  margin: 0;
+  z-index: 60;
 }
 
 /* Footer */

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -275,7 +275,7 @@ export function FileCard({
         )}
         <div className={`file-tile ${showMenu ? "menu-open" : ""} ${selected ? "selected" : ""}`}>
           {/* Preview area */}
-          <div className="file-tile-preview">
+          <div className={`file-tile-preview ${showMenu ? "menu-open" : ""}`}>
             {selectionControl}
             {hasPreview ? (
               <img src={preview} alt={file.name} className="file-tile-img" />
@@ -310,6 +310,7 @@ export function FileCard({
               >
                 ⋮
               </button>
+
               {showMenu && (
                 <div className="file-menu tile-menu" onClick={(e) => e.stopPropagation()}>
                   <button onClick={handleMoveClick} className="move-btn">Move to Folder</button>

--- a/src/components/FileCard.tsx
+++ b/src/components/FileCard.tsx
@@ -33,8 +33,16 @@ function formatDate(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString();
 }
 
+// Session-level preview cache: avoids re-fetching (and re-signing) when
+// navigating between folders. Keyed by previewHash → blob URL.
+const previewCache = new Map<string, string>();
+
 async function getPreview(file: FileMetadata): Promise<string> {
   if (!file.previewHash) return "";
+
+  const cached = previewCache.get(file.previewHash);
+  if (cached) return cached;
+
   const client = new BlossomClient(file.server);
   const auth = await createAuthEvent("get", `Get preview ${file.previewHash}`, file.previewHash);
   const uint8arr = await client.download(file.previewHash, auth);
@@ -42,6 +50,8 @@ async function getPreview(file: FileMetadata): Promise<string> {
   const decrypted = await decryptFile(ciphertext);
   const blob = new Blob([decrypted as BlobPart], { type: "image/webp" });
   const imageUrl = URL.createObjectURL(blob);
+
+  previewCache.set(file.previewHash, imageUrl);
   return imageUrl;
 }
 
@@ -64,7 +74,13 @@ export function FileCard({
 
   useEffect(() => {
     let cancelled = false;
-    let urlToRevoke: string | null = null;
+
+    // Check cache first — if cached, set immediately without async work
+    if (file.previewHash && previewCache.has(file.previewHash)) {
+      setPreview(previewCache.get(file.previewHash)!);
+      setPreviewloaded(true);
+      return;
+    }
 
     setPreviewloaded(false);
     setPreview(null);
@@ -72,12 +88,7 @@ export function FileCard({
     getPreview(file)
       .then((url) => {
         if (cancelled) return;
-        if (!url) {
-          setPreview(null);
-          return;
-        }
-        urlToRevoke = url;
-        setPreview(url);
+        setPreview(url || null);
       })
       .catch(() => {
         if (cancelled) return;
@@ -90,7 +101,7 @@ export function FileCard({
 
     return () => {
       cancelled = true;
-      if (urlToRevoke) URL.revokeObjectURL(urlToRevoke);
+      // Don't revoke — cached URLs are reused across folder navigation
     };
   }, [file]);
 

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -259,7 +259,7 @@ export function FileList() {
 
   return (
     <div className="file-list-container">
-      <div className="file-list-scroll">
+      <div className="file-list-scroll" style={selectedCount > 0 ? { paddingBottom: 120 } : undefined}>
         <UploadZone />
 
         {bulkError && <div className="bulk-action-error">{bulkError}</div>}
@@ -386,34 +386,36 @@ export function FileList() {
         )}
       </div>
 
-      <div className="bulk-action-bar">
-        <div className="bulk-action-summary">
-          <strong>{selectedCount}</strong> file{selectedCount === 1 ? "" : "s"} selected
+      {selectedCount > 0 && (
+        <div className="bulk-action-bar">
+          <div className="bulk-action-summary">
+            <strong>{selectedCount}</strong> file{selectedCount === 1 ? "" : "s"} selected
+          </div>
+          <div className="bulk-action-buttons">
+            <button
+              className="bulk-secondary-btn"
+              onClick={() => setShowMoveDialog(true)}
+              disabled={bulkAction !== null}
+            >
+              {bulkAction === "move" ? "Moving..." : "Move selected"}
+            </button>
+            <button
+              className="bulk-danger-btn"
+              onClick={handleRequestBulkDelete}
+              disabled={bulkAction !== null}
+            >
+              {bulkAction === "delete" ? "Deleting..." : "Delete selected"}
+            </button>
+            <button
+              className="bulk-clear-btn"
+              onClick={handleClearSelection}
+              disabled={bulkAction !== null}
+            >
+              Clear
+            </button>
+          </div>
         </div>
-        <div className="bulk-action-buttons">
-          <button
-            className="bulk-secondary-btn"
-            onClick={() => setShowMoveDialog(true)}
-            disabled={bulkAction !== null || selectedCount === 0}
-          >
-            {bulkAction === "move" ? "Moving..." : "Move selected"}
-          </button>
-          <button
-            className="bulk-danger-btn"
-            onClick={handleRequestBulkDelete}
-            disabled={bulkAction !== null || selectedCount === 0}
-          >
-            {bulkAction === "delete" ? "Deleting..." : "Delete selected"}
-          </button>
-          <button
-            className="bulk-clear-btn"
-            onClick={handleClearSelection}
-            disabled={bulkAction !== null || selectedCount === 0}
-          >
-            Clear
-          </button>
-        </div>
-      </div>
+      )}
       {bulkDeleteDialog}
       {bulkMoveDialog}
     </div>

--- a/src/signer/NIP07Signer.ts
+++ b/src/signer/NIP07Signer.ts
@@ -21,18 +21,17 @@ export const nip07Signer: NostrSigner = {
   },
 
   nip44Decrypt: async (pubkey: string, ciphertext: string): Promise<string> => {
-    const decrypt = window.nostr?.nip44?.decrypt;
-    if (!decrypt) {
+    if (!window.nostr?.nip44?.decrypt) {
       throw new Error("NIP-44 decryption not supported");
     }
 
     try {
-      return await (decrypt as (peerPubkey: string, value: string) => Promise<string>)(
+      return await (window.nostr.nip44.decrypt as (peerPubkey: string, value: string) => Promise<string>)(
         pubkey,
         ciphertext,
       );
     } catch {
-      return (decrypt as (params: { pubkey: string; ciphertext: string }) => Promise<string>)({
+      return (window.nostr.nip44.decrypt as (params: { pubkey: string; ciphertext: string }) => Promise<string>)({
         pubkey,
         ciphertext,
       });

--- a/src/signer/manager.ts
+++ b/src/signer/manager.ts
@@ -195,12 +195,26 @@ class SignerManager {
           null,
         );
 
-        if (profile?.pubkey && window.nostr) {
-          this.signer = nip07Signer;
-          this.pubkey = profile.pubkey;
-          await setStoredItem(STORAGE_KEYS.AUTH_METHOD, "nip07");
-          this.notify();
-          return profile.pubkey;
+        if (profile?.pubkey) {
+          // NIP-07 extensions inject window.nostr asynchronously; wait for it
+          let nostrAvailable = !!window.nostr;
+          if (!nostrAvailable) {
+            for (let attempt = 0; attempt < 10; attempt++) {
+              await new Promise((r) => setTimeout(r, 200));
+              if (window.nostr) {
+                nostrAvailable = true;
+                break;
+              }
+            }
+          }
+
+          if (nostrAvailable) {
+            this.signer = nip07Signer;
+            this.pubkey = profile.pubkey;
+            await setStoredItem(STORAGE_KEYS.AUTH_METHOD, "nip07");
+            this.notify();
+            return profile.pubkey;
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
### Problem
@abh3po @geralt-debugs 
After merging PRs #30 and #33, the current codebase has three regressions:

1. **Files don't load** — Drive shows "No files or folders" despite having data on relays
2. **Bulk action bar always visible** — "0 files selected / Move selected / Delete selected" renders permanently at the bottom
3. **Repeated signer prompts** — Navigating between folders re-fetches previews, triggering NIP-07 signing prompts every time

### Root Causes

**Files not loading:** `NIP07Signer.nip44Decrypt` extracts `window.nostr.nip44.decrypt` as a standalone function reference, stripping the `this` context the extension needs. All 5 events fetch successfully but every decryption silently fails (caught by `console.debug`). Additionally, `window.nostr` may not be injected yet when `restoreFromStorage` runs — NIP-07 extensions inject asynchronously.

**Bulk bar:** `FileList.tsx` renders the bulk action bar unconditionally — it should only appear when `selectedCount > 0`.

**Signer spam:** `FileCard` calls `getPreview()` on every mount, which requires 2 signing operations per file (auth event + NIP-44 decrypt). Navigating folders remounts cards, re-triggering all prompts.

Current code on main 
<img width="1910" height="872" alt="image" src="https://github.com/user-attachments/assets/fdad7a9b-062b-4588-bd42-d2d98253769e" />

This fix 

https://github.com/user-attachments/assets/6a85e537-d170-4cdd-aa16-58a7c4c908d8


