### PR TITLE
ci: add build debug APK workflow using shared reusable workflow

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -47,7 +47,7 @@ jobs:
 
   build:
     needs: resolve-pr
-    uses: formstr-hq/common-packages/.github/workflows/reusable-build-debug-apk.yml@master
+    uses: formstr-hq/common-packages/.github/workflows/reusable-build-debug-apk.yml@main
     with:
       pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
       pr_sha: ${{ needs.resolve-pr.outputs.pr_sha }}

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,54 @@
+name: Build Debug APK (PR + Manual)
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  resolve-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+      pr_sha: ${{ steps.pr.outputs.sha }}
+    steps:
+      - name: Resolve PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            }
+
+            if (context.eventName === "workflow_dispatch") {
+              const prNumber = Number('${{ inputs.pr_number }}');
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              })).data;
+            }
+
+            core.setOutput('number', String(pr.number));
+            core.setOutput('sha', pr.head.sha);
+
+  build:
+    needs: resolve-pr
+    uses: formstr-hq/common-packages/.github/workflows/reusable-build-debug-apk.yml@master
+    with:
+      pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
+      pr_sha: ${{ needs.resolve-pr.outputs.pr_sha }}
+      package_manager: "pnpm"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-debug-apk.yml` — triggers on `pull_request: labeled` and `workflow_dispatch`
- Delegates all build steps to `formstr-hq/common-packages/.github/workflows/reusable-build-debug-apk.yml@main`
- Configured for pnpm (matches existing `pnpm-lock.yaml`)

## Dependency

Requires `formstr-hq/common-packages` PR to be merged first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJf7HQuKwGvJwtY96CcGsy)_