### PR TITLE
ci: add build-apk and build-ios workflows

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   resolve-pr:
-    if: github.event.label.name == 'build-app' || github.event_name == 'workflow_dispatch'
+    if: github.event.label.name == 'build-apk' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  issues: write
 
 jobs:
   resolve-pr:

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   resolve-pr:
+    if: github.event.label.name == 'build-app' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/build-debug-ios.yml
+++ b/.github/workflows/build-debug-ios.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  issues: write
 
 jobs:
   resolve-pr:

--- a/.github/workflows/build-debug-ios.yml
+++ b/.github/workflows/build-debug-ios.yml
@@ -1,0 +1,56 @@
+name: Build Debug iOS (PR + Manual)
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  resolve-pr:
+    if: github.event.label.name == 'build-ios' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+      pr_sha: ${{ steps.pr.outputs.sha }}
+    steps:
+      - name: Resolve PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            }
+
+            if (context.eventName === "workflow_dispatch") {
+              const prNumber = Number('${{ inputs.pr_number }}');
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              })).data;
+            }
+
+            core.setOutput('number', String(pr.number));
+            core.setOutput('sha', pr.head.sha);
+
+  build:
+    needs: resolve-pr
+    uses: formstr-hq/common-packages/.github/workflows/reusable-build-debug-ios.yml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ needs.resolve-pr.outputs.pr_number }}
+      pr_sha: ${{ needs.resolve-pr.outputs.pr_sha }}
+      package_manager: "pnpm"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-debug-apk.yml` — triggers on `build-apk` label or `workflow_dispatch`, delegates to shared reusable workflow (pnpm)
- Adds `.github/workflows/build-debug-ios.yml` — triggers on `build-ios` label or `workflow_dispatch`, delegates to shared reusable iOS workflow (pnpm)

## Dependency

Requires `formstr-hq/common-packages` PR #5 to be merged first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJf7HQuKwGvJwtY96CcGsy)_