### PR TITLE
fix: support commenting and labeling on fork PRs

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,7 +1,7 @@
 name: Build Debug APK (PR + Manual)
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -29,7 +29,7 @@ jobs:
           script: |
             let pr;
 
-            if (context.eventName === "pull_request") {
+            if (context.eventName === "pull_request" || context.eventName === "pull_request_target") {
               pr = context.payload.pull_request;
             }
 


### PR DESCRIPTION
## Summary

- Switch `pull_request` → `pull_request_target` so `GITHUB_TOKEN` has write permissions when a maintainer labels a fork PR
- Fix `context.eventName` check in `resolve-pr` to match the new event name (`"pull_request_target"`)

## Why

With `pull_request`, GitHub restricts `GITHUB_TOKEN` to read-only for fork PRs — even when triggered by a maintainer adding a label. `pull_request_target` runs in the base repo context and grants write access, which is safe here since the trigger is `labeled` (requires a maintainer action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)